### PR TITLE
Optionally receive coverage in body, other params in query

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -280,20 +280,25 @@ router.get( "/repo/:owner/:name/:hash/:file(*)",
 
 router.post( "/coverage", function( req, res, next )
 {
+    var onCoverageSaved = function ( err )
+    {
+        if( err )
+        {
+            return res.status( 404 ).send( err.message ).end();
+        }
+
+        return res.status( 201 ).end();
+    };
+
     if( req.body.token && req.body.commit && req.body.coverage )
     {
-        var onCoverageSaved = function ( err )
-        {
-            if( err )
-            {
-                return res.status( 404 ).send( err.message ).end();
-            }
-
-            return res.status( 201 ).end();
-        };
-
         return saveCoverage( req.body.token, req.body.commit,
             req.body.coverage, req.body.coveragetype || "lcov", onCoverageSaved );
+    }
+    else if( req.query.token && req.query.commit && req.body )
+    {
+        return saveCoverage( req.query.token, req.query.commit,
+            req.body, req.query.coveragetype || "lcov", onCoverageSaved );
     }
 
     res.status( 400 ).end();


### PR DESCRIPTION
I think this does more or less what @jrit described in #19, though I left the existing code intact so that the existing instructions won't be wrong per se, it'll just have the additional ability to take coverage-only in the body and the rest of the parameters in the query.
