### PR TITLE
prevent line drifting

### DIFF
--- a/public/styles/prism.css
+++ b/public/styles/prism.css
@@ -14,7 +14,7 @@ pre[class*="language-"] {
     white-space: pre;
     word-spacing: normal;
     word-break: normal;
-    line-height: 1.5;
+    line-height: 20px;
 
     -moz-tab-size: 4;
     -o-tab-size: 4;

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -14,7 +14,7 @@ pre[class*="language-"] {
     white-space: pre;
     word-spacing: normal;
     word-break: normal;
-    line-height: 1.5;
+    line-height: 20px;
 
     -moz-tab-size: 4;
     -o-tab-size: 4;


### PR DESCRIPTION
fixes #39 

Looks like Chrome doesn't actually render anything except integer line heights even though it reports whatever the input CSS value is. So the half pixel difference per line was causing the drifting.

@vokal-isaac 
