### PR TITLE
webhooks and token weirdness

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -12,6 +12,7 @@ var repoSchema = mongoose.Schema({
     name: String,
     fullName: String,
     token: String,
+    webhookId: String,
     commits: [{
         hash: String,
         coverage: String,
@@ -30,17 +31,24 @@ repoSchema.statics.findFullNameInArray = function ( repoFullNames, cb )
     return this.find( { fullName: { $in: repoFullNames } }, cb );
 };
 
-var userSchema = mongoose.Schema({
+var userSchema = mongoose.Schema( {
     oauth: {
         provider: String,
-        username: String
+        username: String,
+        token: String
     },
     repos: [{
         owner: String,
         name: String,
         fullName: String
     }]
-});
+} );
+
+userSchema.statics.getTokenForRepoFullName = function ( repoFullName, cb )
+{
+    return this.findOne( { "repos.fullName": repoFullName }, "oauth.token", cb );
+};
+
 
 models.Repo = mongoose.model( "repo", repoSchema );
 models.User = mongoose.model( "user", userSchema );


### PR DESCRIPTION
This won't deploy correctly until https://github.com/vokal/cvr/pull/20 is merged.

On a PR webhook, this looks through mongo to find a user that has the repo with the PR and pulls their token. To do that, mongo is now storing github tokens. The token is used to set the PR status to pending.

When coverage is later posted, the status will be set to passing/failing based on coverage being over 80% right now. This will end up failing some projects, but the intent is to have that number configurable per repo. I'd like to actually see the calls all working together in production and then worry about that setting.

@scottferg 
