### PR TITLE
prevent setting pending on PR close

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -646,7 +646,7 @@ router.post( "/webhook", function ( req, res, next )
 
     var pr = req.body.pull_request;
 
-    if( !pr || req.body.action === "closed" )
+    if( !pr || [ "opened", "synchronize" ].indexOf( req.body.action ) === -1 )
     {
         return res.status( 202 ).send( "Not a Pull Request" ).end();
     }


### PR DESCRIPTION
fixes #73 

When a merge occurs on GitHub, there are two hooks fired. One is `push` which indicates code is moved into master. The other is `pull_request` where the action is `closed` as opposed to the `open` or `synchronize` actions that indicate an event that should cause the status to be pending.

@vokal-isaac 
