### PR TITLE
Use `git+https` to stop `npm install` from failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "body-parser": "~1.12.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "~1.3.4",
-    "cvr": "git+ssh://github.com/vokal/cvr.git",
+    "cvr": "git+https://github.com/vokal/cvr.git",
     "debug": "~2.1.1",
     "express": "~4.12.2",
     "express-session": "^1.11.1",


### PR DESCRIPTION
Needed to update this to get `cvr-view` to correctly access the `cvr` repo. @jrit @Deanzie 
