### PR TITLE
Honor X-Forwarded-* headers when living behind a reverse proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ if( process.env.GITHUB_ORGS_WHITELIST )
 var app = express();
 
 // proxy setup
-app.set('trust proxy', 'loopback');
+app.set( "trust proxy", "loopback" );
 
 // view engine setup
 app.set( "views", path.join( __dirname, "views" ));


### PR DESCRIPTION
@jrit This needs to be set so that Nginx can tell the app that the request was made using HTTPS. Without it `req.protocol` always returns HTTP.
