### PR TITLE
Better coverage type matching

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -61,8 +61,8 @@ router.get( "/upload", function( req, res, next )
 {
     res.set( "Content-Type", "text/plain" );
     res.render( "upload", {
-        lcov_regex: lcovFnMatch,
-        gocov_regex: gocoverMatch,
+        lcovRegex: lcovFnMatch,
+        gocovRegex: gocoverMatch,
         proto: req.protocol,
         host: req.hostname
     } )

--- a/views/upload.html
+++ b/views/upload.html
@@ -5,8 +5,8 @@ GIT_HASH=$(git rev-parse HEAD)
 COVERAGE_TYPE=""
 COVERAGE_FILE=""
 
-LCOV_FN_MATCH="{{ lcov_regex }}"
-GOCOVER_MATCH="{{ gocov_regex }}"
+LCOV_FN_MATCH="{{ lcovRegex }}"
+GOCOVER_MATCH="{{ gocovRegex }}"
 
 # This is a naive hack. There are many like it but this one is mine.
 get_coverage_type() {


### PR DESCRIPTION
@jrit @vokal-isaac this one will improve matching for Go coverage reports as well as LCOV. Also I fixed the curl parameters to boot.

@jrit I'm only matching `FN` which is a function. I think that should be sufficient but there are a number of line variants in LCOV that might make it worth adding some more options in the future.
