### PR TITLE
improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvr-view",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "MIT",
   "scripts": {
     "start": "node ./bin/www",

--- a/routes/commit.js
+++ b/routes/commit.js
@@ -4,99 +4,109 @@ var cvr = require( "cvr" );
 var models = require( "../lib/models" );
 var env = require( "../lib/env" );
 var uuid = require( "node-uuid" );
+var a = require( "async" );
 
 module.exports = function ( req, res, next )
 {
-    var onRepo = function ( err, repo )
+    var repo = null;
+    var hashes = null;
+    var commit = null;
+
+    a.waterfall( [
+        function ( done )
+        {
+            models.Repo.findByOwnerAndName( req.params.owner, req.params.name, done );
+        },
+        function ( _repo, done )
+        {
+            repo = _repo;
+            if( !repo )
+            {
+                repo = new models.Repo( {
+                    provider: "github",
+                    owner: req.params.owner,
+                    name: req.params.name,
+                    fullName: req.params.owner + "/" + req.params.name,
+                    token: uuid.v4().replace( /-/g, "" )
+                } );
+                repo.save();
+            }
+
+            cvr.createGitHubHook( req.session.user.token, repo.owner, repo.name, env.host + "webhook", function ( err )
+            {
+                if( err )
+                {
+                    console.log( "failed to create hook" );
+                }
+            } );
+
+            models.Commit.findCommitList( repo.owner, repo.name, done );
+        },
+        function ( _hashes, done )
+        {
+            hashes = _hashes;
+            if( hashes && hashes.length !== 0 )
+            {
+                if( req.params.hash )
+                {
+                    models.Commit.findCommit( repo.owner, repo.name, req.params.hash, done );
+                }
+                else
+                {
+                    models.Commit.findCommit( repo.owner, repo.name, hashes[ 0 ].hash, done );
+                }
+                return;
+            }
+
+            res.render( "commit-activate", {
+                layout: "layout.html",
+                repo: repo,
+                authed: true } );
+
+            done( new Error( "new repo" ) );
+        },
+        function ( _commit, done )
+        {
+            commit = _commit;
+            if( !commit )
+            {
+                var commit404 = new Error( "Commit not found" );
+                commit404.status = 404;
+                return done( commit404 );
+            }
+
+            cvr.getCoverage( commit.coverage, commit.coverageType, done );
+        },
+        function ( cov, done )
+        {
+            cvr.sortCoverage( cov )
+                .forEach( function ( file )
+                {
+                    file.linePercent = cvr.getLineCoveragePercent( [ file ] );
+                } );
+
+            res.render( "commit", {
+                layout: "layout.html",
+                repo: repo,
+                commit: repo.commits[ 0 ] || commit,
+                cov: cov,
+                hash: commit.hash,
+                isPullRequest: commit.isPullRequest,
+                hashes: hashes,
+                authed: true } );
+
+            done();
+        }
+    ], function ( err, results )
     {
         if( err )
         {
-            return next( err );
+            if( err.message === "new repo" )
+            {
+                return;
+            }
+
+            next( err );
         }
-
-        if( !repo )
-        {
-            repo = new models.Repo({
-                provider: "github",
-                owner: req.params.owner,
-                name: req.params.name,
-                fullName: req.params.owner + "/" + req.params.name,
-                token: uuid.v4().replace( /-/g, "" )
-            });
-            repo.save();
-        }
-
-        cvr.createGitHubHook( req.session.user.token, repo.owner, repo.name, env.host + "webhook", function ( err )
-        {
-            if( err )
-            {
-                console.log( "failed to create hook" );
-            }
-        } );
-
-        var onHashList = function ( err, hashes )
-        {
-            if( err )
-            {
-                return next( err );
-            }
-
-            if( !hashes || hashes.length === 0 )
-            {
-                return res.render( "commit-activate", {
-                    layout: "layout.html",
-                    repo: repo,
-                    authed: true } );
-            }
-
-            var onCommit = function ( err, commit )
-            {
-                if( err || !commit )
-                {
-                    var commit404 = new Error( "Commit not found" );
-                    commit404.status = 404;
-                    return next( commit404 );
-                }
-
-                var onCov = function ( err, cov )
-                {
-                    if( err )
-                    {
-                        return next( err );
-                    }
-
-                    cvr.sortCoverage( cov )
-                        .forEach( function ( file )
-                        {
-                            file.linePercent = cvr.getLineCoveragePercent( [ file ] );
-                        } );
-
-                    res.render( "commit", {
-                        layout: "layout.html",
-                        repo: repo,
-                        commit: repo.commits[ 0 ] || commit,
-                        cov: cov,
-                        hash: commit.hash,
-                        isPullRequest: commit.isPullRequest,
-                        hashes: hashes,
-                        authed: true } );
-                };
-
-                cvr.getCoverage( commit.coverage, commit.coverageType, onCov );
-            };
-
-            if( req.params.hash )
-            {
-                models.Commit.findCommit( repo.owner, repo.name, req.params.hash, onCommit );
-            }
-            else
-            {
-                models.Commit.findCommit( repo.owner, repo.name, hashes[ 0 ].hash, onCommit );
-            }
-        };
-
-        models.Commit.findCommitList( repo.owner, repo.name, onHashList );
-    };
-
-    models.Repo.findByOwnerAndName( req.params.owner, req.params.name, onRepo );
+    } );
 };

--- a/routes/coverage-abort.js
+++ b/routes/coverage-abort.js
@@ -1,0 +1,85 @@
+"use strict";
+
+var cvr = require( "cvr" );
+var models = require( "../lib/models" );
+
+module.exports = function ( req, res, next )
+{
+    var captureOn = req.body.commit ? req.body : req.query;
+
+    var options = {
+        token: captureOn.token,
+        owner: captureOn.owner,
+        repo: captureOn.repo,
+        commit: captureOn.commit,
+        reason: captureOn.reason
+    };
+
+    if( !captureOn.commit )
+    {
+        return res.status( 400 ).send( "Commit is required" );
+    }
+
+    var onDone = function ( err )
+    {
+        if( err )
+        {
+            return res.status( 400 ).send( err );
+        }
+
+        return res.status( 201 ).send( "Status created" );
+    };
+
+    var abortPendingStatus = function ( options )
+    {
+        if( !options.gitHubOauthToken )
+        {
+            onDone( new Error( "Unable to get oauth token" ) );
+        }
+
+        var status = {
+            user: options.owner,
+            repo: options.repo,
+            sha: options.commit,
+            state: "failure",
+            context: "cvr",
+            description: options.reason || "coverage aborted"
+        };
+
+        cvr.createGitHubStatus( options.gitHubOauthToken, status, onDone );
+    };
+
+    var onOauthToken = function ( err, tokenRes )
+    {
+        if( err )
+        {
+            return onDone( err );
+        }
+
+        options.gitHubOauthToken = tokenRes && tokenRes.oauth ? tokenRes.oauth.token : null;
+        abortPendingStatus( options );
+    };
+
+    if( options.owner && options.repo )
+    {
+        models.User.getTokenForRepoFullName( options.owner + "/" + options.repo, onOauthToken );
+    }
+    else if( options.token )
+    {
+        models.Repo.findByToken( options.token, function ( err, repo )
+        {
+            if( err )
+            {
+                return onDone( err );
+            }
+
+            options.owner = repo.owner;
+            options.repo = repo.name;
+            models.User.getTokenForRepoFullName( repo.fullName, onOauthToken );
+        } );
+    }
+    else
+    {
+        return onDone( new Error( "Token or owner and repo are required" ) );
+    }
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -54,6 +54,7 @@ router.get( "/upload", require( "./upload" ) );
 router.get( "/:owner/:name/shield.svg", require( "./shield" ) );
 
 router.post( "/coverage", require( "./coverage" ) );
+router.post( "/coverage/abort", require( "./coverage-abort" ) );
 router.post( "/webhook", require( "./webhook" ) );
 
 router.get( "/auth/github", passport.authenticate( "github" ) );

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -15,7 +15,8 @@ module.exports = function ( req, res, next )
             return res.status( 400 ).send( "Unable to set pending status to "
                 + status.user + "/" + status.repo + "/" + status.sha + " as "
                 + oauth.username
-                + ", user's oauth token may have expired or not have push access for the repo: " + err );
+                + ", user's oauth token may have expired, not have push access for the repo, "
+                + "or the sha may not exist: " + err );
         }
 
         return res.status( 201 ).send( "Created status" );

--- a/run-build.sh
+++ b/run-build.sh
@@ -7,6 +7,8 @@ RESULT=$?
 if [ $RESULT == 0 ]; then
   GITHASH="$(git rev-parse HEAD)"
   curl -F coverage=@coverage/lcov.info "https://cvr.vokal.io/coverage?token=$CVR_TOKEN&commit=$GITHASH&removepath=/var/cache/drone/src/github.com/vokal/cvr-view/&coveragetype=lcov"
+else
+  curl -X POST "https://cvr.vokal.io/coverage/abort?token=$CVR_TOKEN&commit=$GITHASH"
 fi
 
 exit $RESULT

--- a/test/coverage.js
+++ b/test/coverage.js
@@ -124,4 +124,20 @@ module.exports = function ()
                 done( err );
             } );
     } );
+
+    it( "should abort pending coverage", function ( done )
+    {
+        request( server )
+            .post( "/coverage/abort" )
+            .field( "commit", "627786ba8f153d46e808c9b6c2755fa5ce38de6d" )
+            .field( "owner", "vokal" )
+            .field( "repo", "cvr-view" )
+            .field( "reason", "This was a test" )
+            .expect( 201 )
+            .end( function ( err, res )
+            {
+                assert.equal( res.text, "Status created" );
+                done( err );
+            } );
+    } );
 };


### PR DESCRIPTION
- really verbose err message when unable to set a status
- [semver-minor] new route that allows status to be set to failed to be used when a build fails as an improvement from the current permanently pending status
- refactor commit.js to be more comprehensible
- use the new abort route with this repo

@dmaloneycalu please have a look